### PR TITLE
Potential fix for code scanning alert no. 5: Unsafe HTML constructed from library input

### DIFF
--- a/wwwroot/lib/jquery/dist/jquery.js
+++ b/wwwroot/lib/jquery/dist/jquery.js
@@ -1275,10 +1275,21 @@ function setDocument( node ) {
 
 		var input;
 
-		documentElement.appendChild( el ).innerHTML =
-			"<a id='" + expando + "' href='' disabled='disabled'></a>" +
-			"<select id='" + expando + "-\r\\' disabled='disabled'>" +
-			"<option selected=''></option></select>";
+		var anchor = document.createElement("a");
+		anchor.setAttribute("id", expando);
+		anchor.setAttribute("href", "");
+		anchor.setAttribute("disabled", "disabled");
+		el.appendChild(anchor);
+
+		var select = document.createElement("select");
+		select.setAttribute("id", expando + "-\r\\");
+		select.setAttribute("disabled", "disabled");
+
+		var option = document.createElement("option");
+		option.setAttribute("selected", "");
+		select.appendChild(option);
+
+		el.appendChild(select);
 
 		// Support: iOS <=7 - 8 only
 		// Boolean attributes and "value" are not treated correctly in some XML documents


### PR DESCRIPTION
Potential fix for [https://github.com/KAZL0/PoliceStation/security/code-scanning/5](https://github.com/KAZL0/PoliceStation/security/code-scanning/5)

To fix the issue, we need to ensure that the dynamically constructed HTML is safe. This can be achieved by:
1. Avoiding the use of `innerHTML` for constructing HTML whenever possible. Instead, use safer alternatives like `createElement` and `appendChild`.
2. If `innerHTML` must be used, sanitize or escape the input to prevent XSS vulnerabilities.

In this case, we will replace the use of `innerHTML` with DOM manipulation methods (`createElement`, `setAttribute`, etc.) to safely construct the required HTML structure. This ensures that no untrusted input can lead to XSS.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
