### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and Test


### PR DESCRIPTION
Potential fix for [https://github.com/KAZL0/PoliceStation/security/code-scanning/1](https://github.com/KAZL0/PoliceStation/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for the current workflow since it only needs to read the repository contents to build and test the project. This change ensures that the workflow does not inadvertently inherit broader permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
